### PR TITLE
add file for ignoring preview builds

### DIFF
--- a/client/vercel-ignore-preview.sh
+++ b/client/vercel-ignore-preview.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "VERCEL_ENV: $VERCEL_ENV"
+
+if [[ "$VERCEL_ENV" == "production" ]] ; then
+  # Proceed with the build
+  echo "✅ - Build can proceed"
+  exit 1;
+
+else
+  # Don't build
+  echo "🛑 - Build cancelled"
+  exit 0;
+fi

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,5 @@
+{
+	"github": {
+		"silent": true
+	}
+}


### PR DESCRIPTION
the shell script disables vercel on building each time a branch is pushed.
with this, we wont have preview links anymore